### PR TITLE
fix: run scheduled group analysis concurrently

### DIFF
--- a/src/service/analysis.ts
+++ b/src/service/analysis.ts
@@ -886,20 +886,23 @@ export class AnalysisService extends Service {
         const enabledGroups = this.config.listenerGroups.filter(
             (group) => group.enabled
         )
-        for (const group of enabledGroups) {
-            try {
-                await this.executeGroupAnalysis(
-                    group.selfId,
-                    { guildId: group.guildId, channelId: group.channelId },
-                    this.config.cronAnalysisDays
-                )
-            } catch (err) {
-                this.ctx.logger.error(
-                    `群 ${group.guildId || group.channelId} 自动分析失败:`,
-                    err
-                )
-            }
-        }
+
+        await Promise.allSettled(
+            enabledGroups.map(async (group) => {
+                try {
+                    await this.executeGroupAnalysis(
+                        group.selfId,
+                        { guildId: group.guildId, channelId: group.channelId },
+                        this.config.cronAnalysisDays
+                    )
+                } catch (err) {
+                    this.ctx.logger.error(
+                        `群 ${group.guildId || group.channelId} 自动分析失败:`,
+                        err
+                    )
+                }
+            })
+        )
     }
 
     public async getUserPersona(

--- a/src/service/analysis.ts
+++ b/src/service/analysis.ts
@@ -886,23 +886,35 @@ export class AnalysisService extends Service {
         const enabledGroups = this.config.listenerGroups.filter(
             (group) => group.enabled
         )
+        const maxConcurrentAnalyses = 3
 
-        await Promise.allSettled(
-            enabledGroups.map(async (group) => {
-                try {
-                    await this.executeGroupAnalysis(
-                        group.selfId,
-                        { guildId: group.guildId, channelId: group.channelId },
-                        this.config.cronAnalysisDays
-                    )
-                } catch (err) {
-                    this.ctx.logger.error(
-                        `群 ${group.guildId || group.channelId} 自动分析失败:`,
-                        err
-                    )
-                }
-            })
-        )
+        for (
+            let index = 0;
+            index < enabledGroups.length;
+            index += maxConcurrentAnalyses
+        ) {
+            const currentBatch = enabledGroups.slice(
+                index,
+                index + maxConcurrentAnalyses
+            )
+
+            await Promise.allSettled(
+                currentBatch.map(async (group) => {
+                    try {
+                        await this.executeGroupAnalysis(
+                            group.selfId,
+                            { guildId: group.guildId, channelId: group.channelId },
+                            this.config.cronAnalysisDays
+                        )
+                    } catch (err) {
+                        this.ctx.logger.error(
+                            `群 ${group.guildId || group.channelId} 自动分析失败:`,
+                            err
+                        )
+                    }
+                })
+            )
+        }
     }
 
     public async getUserPersona(


### PR DESCRIPTION
### Motivation
- The scheduled analysis loop processed enabled groups sequentially which increased total run time when multiple groups were enabled, so it should run analyses concurrently.

### Description
- Replace the serial `for...of` in `executeAutoAnalysisForEnabledGroups` with `Promise.allSettled` to invoke `executeGroupAnalysis` for all enabled groups in parallel while keeping per-group `try/catch` error logging in `src/service/analysis.ts`.

### Testing
- Ran `npx eslint src/service/analysis.ts`, which failed in this environment due to missing `eslint.config.*` (ESLint v9 migration), so linting could not be validated here.
- Ran `npm run build`, which failed due to a `403 Forbidden` when fetching the `yakumo` package from the registry, so a full build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5bfd7df7883338f328f79e7589c90)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Analysis for enabled groups now runs in controlled parallel batches (up to 3 groups at a time) for improved throughput and faster completion.
  * Per-group error handling and logging remain unchanged.
  * Public method signatures and external behavior are unchanged, so callers see no API changes.
  * No user-facing configuration changes required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->